### PR TITLE
Fix Atlassian Marketplace link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To update the marketplace, use the following steps.
 1. Build the JAR file. You can do this locally, or get the JAR file artifact from TeamCity. Note that you will need
    to increment the version inside the pom.xml file before building (`<version>1.0.3</version>`). This version is used 
    by the store to show the latest artifact to end users.
-2. Browse to https://marketplace.atlassian.com/manage/plugins/com.octopus.bamboo/versions. Use the atlassian@octopus.com
+2. Browse to https://marketplace.atlassian.com/plugins/com.octopus.bamboo/versions. Use the atlassian@octopus.com
    account - credentials are in the password manager.
 3. Click the `Create version` button.
 4. Follow the wizard to upload the JAR file. The wizard will show you a lot of pages relating to how the add-on is


### PR DESCRIPTION
Atlassian changed their URL scheme, so the URL needed to be updated