### PR TITLE
Change the `isEmpty` checks on deploymentTimeout

### DIFF
--- a/src/main/java/com/octopus/bamboo/plugins/task/createrelease/CreateReleaseTask.java
+++ b/src/main/java/com/octopus/bamboo/plugins/task/createrelease/CreateReleaseTask.java
@@ -139,7 +139,7 @@ public class CreateReleaseTask extends OctoTask {
         if (deploymentProgressEnabled) {
             commands.add("--progress");
 
-            if (!deploymentTimeout.isEmpty()) {
+            if (StringUtils.isNotBlank(deploymentTimeout)) {
                 commands.add("--deploymenttimeout");
                 commands.add(deploymentTimeout);
             }

--- a/src/main/java/com/octopus/bamboo/plugins/task/deployrelease/DeployReleaseTask.java
+++ b/src/main/java/com/octopus/bamboo/plugins/task/deployrelease/DeployReleaseTask.java
@@ -124,7 +124,7 @@ public class DeployReleaseTask extends OctoTask {
         if (deploymentProgressEnabled) {
             commands.add("--progress");
 
-            if (!deploymentTimeout.isEmpty()) {
+            if (StringUtils.isNotBlank(deploymentTimeout)) {
                 commands.add("--deploymenttimeout");
                 commands.add(deploymentTimeout);
             }

--- a/src/main/java/com/octopus/bamboo/plugins/task/promoterelease/PromoteReleaseTask.java
+++ b/src/main/java/com/octopus/bamboo/plugins/task/promoterelease/PromoteReleaseTask.java
@@ -122,7 +122,7 @@ public class PromoteReleaseTask extends OctoTask {
         if (deploymentProgressEnabled) {
             commands.add("--progress");
 
-            if (!deploymentTimeout.isEmpty()) {
+            if (StringUtils.isNotBlank(deploymentTimeout)) {
                 commands.add("--deploymenttimeout");
                 commands.add(deploymentTimeout);
             }


### PR DESCRIPTION
`isEmpty` isn't null safe, changing the calls to use `StringUtils.isNotBlank`