### PR TITLE
update plugin to work with Bamboo 8+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>2.0.0</version>
     <organization>
         <name>Octopus Deploy</name>
-        <url>http://www.optopus.com/</url>
+        <url>http://www.octopus.com/</url>
     </organization>
     <name>Octopus Deploy Bamboo Plugin</name>
     <description>Octopus Deploy Bamboo plugin for Atlassian Bamboo.</description>
@@ -45,7 +45,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <bamboo.version>7.2.1</bamboo.version>
+        <bamboo.version>8.0.4</bamboo.version>
         <bamboo.data.version>7.2.1</bamboo.data.version>
         <amps.version>8.0.2</amps.version>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <bamboo.version>8.0.4</bamboo.version>
-        <bamboo.data.version>7.2.1</bamboo.data.version>
+        <bamboo.data.version>8.0.4</bamboo.data.version>
         <amps.version>8.0.2</amps.version>
         <!--
             The default version has a bug that prevents integration tests from working

--- a/src/test/java/com/octopus/services/impl/RecordingBuildLogger.java
+++ b/src/test/java/com/octopus/services/impl/RecordingBuildLogger.java
@@ -14,6 +14,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -24,6 +26,7 @@ public class RecordingBuildLogger implements BuildLogger {
     private static final Logger LOGGER = LoggerFactory.getLogger(RecordingBuildLogger.class);
     private final List<LogEntry> buildlogs = new ArrayList<>();
     private final List<LogEntry> errorlogs = new ArrayList<>();
+    private final AtomicLong timeOfLastLog = new AtomicLong(0L);
 
     public List<LogEntry> findErrorLogs(@NotNull final String message) {
         checkNotNull(message);
@@ -108,7 +111,14 @@ public class RecordingBuildLogger implements BuildLogger {
 
     @Override
     public long getTimeOfLastLog() {
-        return 0;
+        return timeOfLastLog.get();
+    }
+
+
+    // NOTE: This is an override, but only exists in Bamboo 8+, thus is left out for Bamboo 7 compatibility
+    public void setTimeOfLastLog(final long l) {
+        timeOfLastLog.set(l);
+
     }
 
     @NotNull

--- a/src/test/java/com/octopus/services/impl/RecordingBuildLogger.java
+++ b/src/test/java/com/octopus/services/impl/RecordingBuildLogger.java
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.Preconditions.checkNotNull;


### PR DESCRIPTION
Updated the bamboo.version from 7.2.6 to 8.0.4 to overcome a recognised vulnerability in the base of Bamboo.

The CVE was announced as 
https://confluence.atlassian.com/security/multiple-products-security-advisory-unrendered-unicode-bidirectional-override-characters-cve-2021-42574-1086419475.html?subid=1529035734&jobid=105251301&utm_campaign=multiple-products-advisory_november-2021_EML-11741&utm_medium=email&utm_source=alert-email

The mocked build logger required update to be 8+ compatible, but otherwise the production code base appears to be already compliant.