### PR TITLE
Fix issue with release notes not being escaped properly

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -58,7 +58,7 @@ step "publish-new-app-version-to-atlassian-marketplace" {
                 latestAppVersion=$(curl --request GET -fSs --url 'https://marketplace.atlassian.com/rest/2/addons/#{addonKey}/versions/latest' --header 'Accept: application/json')
                 bambooCompatibilityVersion=$(get_octopusvariable "Octopus.Action[Push package to Atlassian Marketplace].Output.BambooCompatibilityVersion")
                 bambooBuildNumber=$(curl --request GET -fSs --url "https://marketplace.atlassian.com/rest/2/products/key/bamboo/versions/name/$bambooCompatibilityVersion" | jq '.buildNumber')
-                jsonEscapedReleaseNotes='#{Octopus.Release.Notes | MarkdownToHtml | JsonEscape | Replace "\\n" "\\n" }'
+                jsonEscapedReleaseNotes='#{Octopus.Release.Notes | MarkdownToHtml | JsonEscape | Replace "\\n" "<br/>" }'
                 
                 newAppVersion=$(echo $latestAppVersion \
                     | jq 'del(._links.self)' \

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -58,6 +58,7 @@ step "publish-new-app-version-to-atlassian-marketplace" {
                 latestAppVersion=$(curl --request GET -fSs --url 'https://marketplace.atlassian.com/rest/2/addons/#{addonKey}/versions/latest' --header 'Accept: application/json')
                 bambooCompatibilityVersion=$(get_octopusvariable "Octopus.Action[Push package to Atlassian Marketplace].Output.BambooCompatibilityVersion")
                 bambooBuildNumber=$(curl --request GET -fSs --url "https://marketplace.atlassian.com/rest/2/products/key/bamboo/versions/name/$bambooCompatibilityVersion" | jq '.buildNumber')
+                jsonEscapedReleaseNotes='#{Octopus.Release.Notes | MarkdownToHtml | JsonEscape | Replace "\\n" "\\n" }'
                 
                 newAppVersion=$(echo $latestAppVersion \
                     | jq 'del(._links.self)' \
@@ -71,7 +72,7 @@ step "publish-new-app-version-to-atlassian-marketplace" {
                     | jq '.compatibilities[0].hosting.server.max.build='$bambooBuildNumber \
                     | jq '.compatibilities[0].hosting.server.max.version="'$bambooCompatibilityVersion'"' \
                     | jq '.text.releaseSummary="#{Octopus.Release.Number}"' \
-                    | jq '.text.releaseNotes="#{Octopus.Release.Notes | MarkdownToHtml | JsonEscape }"')
+                    | jq '.text.releaseNotes="'$jsonEscapedReleaseNotes'"')
                 
                 echo "Creating new app version '#{Octopus.Release.Number}'"
                 echo '##octopus[stdout-verbose]'


### PR DESCRIPTION
Deploy of version [2.4.5](https://deploy.octopus.app/app#/Spaces-62/projects/bamboo-plugin/deployments/releases/2.4.5/deployments/Deployments-226863) failed with the following error

`Illegal unquoted character ((CTRL-CHAR, code 10)): has to be escaped using backslash to be included in string value`

It seems it has an issue with `\n` in the release notes, so I've updated the deployment process to replace `\n` with HTML line breaks (`<br/>`) instead.