### PR TITLE
Update to remove explicit setting of reviewers on the compat check workflow

### DIFF
--- a/.github/workflows/bamboo-compatibility-check.yml
+++ b/.github/workflows/bamboo-compatibility-check.yml
@@ -120,4 +120,4 @@ jobs:
           body="Fixes ${{ needs.create-issue.outputs.gh-issue-url }}"
           head="${{ needs.update-pom.outputs.branch }}"
           
-          gh pr create --title "$title" --body "$body" --base "main" --head "$head" --reviewer "OctopusDeploy/team-integrations-fnm"
+          gh pr create --title "$title" --body "$body" --base "main" --head "$head"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*    OctopusDeploy/team-integrations-fnm

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*    OctopusDeploy/team-integrations-fnm
+*    @OctopusDeploy/team-integrations-fnm


### PR DESCRIPTION
Specifying the org level team in the workflow causes the requirements on the bot's token to be higher than we'd like.

This PR update the workflow to rely on the updated repo settings, which will force the code owners to do a review.