### PR TITLE
Update StubCommonContext to match contract, part of the Version Bump

### DIFF
--- a/src/test/java/com/octopus/services/impl/StubCommonContext.java
+++ b/src/test/java/com/octopus/services/impl/StubCommonContext.java
@@ -155,4 +155,9 @@ public class StubCommonContext implements CommonContext {
     public boolean isVerboseLoggingOn() {
         return false;
     }
+
+    @Override
+    public boolean isExpectingDedicatedEphemeralAgent() {
+        return false;
+    }
 }


### PR DESCRIPTION
GHAs were disabled automatically as they haven't been run for some time, which didn't run the tests as part of the pipeline for #67. This is to fix the tests which came from the bamboo dependency update which needed tests to be updated. [Failing workflow](https://github.com/OctopusDeploy/Octopus-Bamboo/actions/runs/4370084164/jobs/7644616070)

I have enabled the workflows.

Screenshot below shows when `mvn test` is run locally.
** Before **
![image](https://user-images.githubusercontent.com/97423717/223899621-3385fc4a-a385-4eca-b39e-ec4cd8f61d56.png)

** After **
![image](https://user-images.githubusercontent.com/97423717/223899670-b7da736e-d849-4992-b1b4-fb3d94bb0e1a.png)
