### PR TITLE
Update Bamboo version compatibility check workflow

### DIFF
--- a/.github/workflows/bamboo-compatibility-check.yml
+++ b/.github/workflows/bamboo-compatibility-check.yml
@@ -4,23 +4,22 @@ on:
   schedule:
     # Monday 8am AEST (Sunday 10pm UTC)
     - cron: '0 22 * * 0'
-
+  
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 env:
-  GH_TOKEN: ${{ secrets.INTEGRATIONS_FNM_BOT_TOKEN }}
+  GH_TOKEN: ${{ secrets.INTEGRATIONS_FNM_BOT_TOKEN }} # needed for github cli
   GITHUB_TOKEN: ${{ secrets.INTEGRATIONS_FNM_BOT_TOKEN }}
 
 jobs:
   check-for-update:
-    name: 'Check for new version'
+    name: 'Check if new version of Bamboo has been released'
     runs-on: 'ubuntu-latest'
 
     outputs:
-      update-available: ${{ steps.version-check.outputs.update-available }}
-      compatible-version: ${{ steps.version-check.outputs.current-compatible-version }}
-      bamboo-version: ${{ steps.version-check.outputs.latest-bamboo-version }}
-      gh-issue-url: ${{ steps.create-issue.outputs.issue-url }}
+      current-compatible-version: ${{ steps.version-check.outputs.current-compatible-version }}
+      latest-bamboo-version: ${{ steps.version-check.outputs.latest-bamboo-version }}
 
     steps:
       - uses: actions/checkout@v3
@@ -29,45 +28,58 @@ jobs:
         id: version-check
         run: |
           # get the version our plugin is compatible with
-          currentCompatibleVersion=$(curl -sS -X GET https://marketplace.atlassian.com/rest/2/addons/com.octopus.bamboo/versions/latest | jq '.compatibilities[0].hosting.server.max.version')
-          echo $currentCompatibleVersion
+          currentCompatibleVersion=$(curl -sS -X GET https://marketplace.atlassian.com/rest/2/addons/com.octopus.bamboo/versions/latest | jq -r '.compatibilities[0].hosting.server.max.version')
           # get latest available version of Bamboo
-          latestBambooVersion=$(curl -sS -X GET https://marketplace.atlassian.com/rest/2/products/key/bamboo/versions/latest | jq '.name')
-          echo $latestBambooVersion
-          echo "::set-output name=update-available::true"
-          echo "::set-output name=current-compatible-version::$currentCompatibleVersion"
-          echo "::set-output name=latest-bamboo-version::$latestBambooVersion"
+          latestBambooVersion=$(curl -sS -X GET https://marketplace.atlassian.com/rest/2/products/key/bamboo/versions/latest | jq -r '.name')
+
+          if [ "$currentCompatibleVersion" == "$latestBambooVersion" ]
+          then
+            # no update required, bail out of workflow run early
+            echo "No update required, cancelling this run"
+            gh run cancel ${{ github.run_id }}
+          fi
+
+          echo "current-compatible-version=$currentCompatibleVersion" >> $GITHUB_OUTPUT
+          echo "latest-bamboo-version=$latestBambooVersion" >> $GITHUB_OUTPUT
 
   create-issue:
     name: 'Create issue'
     runs-on: 'ubuntu-latest'
 
     needs: check-for-update
-    if: ${{ needs.check-for-update.outputs.update-available }}
 
     outputs:
-      gh-issue-url: ${{ steps.create-issue.outputs.issue-url }}
+      gh-issue-url: ${{ steps.create-or-update-issue.outputs.issue-url }}
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: 'Create Issue for new Bamboo version'
-        id: create-issue
+      - name: 'Create or Update Issue for new Bamboo version'
+        id: create-or-update-issue
         run: |
-          compatibleBambooVersion=${{ needs.check-for-update.outputs.compatible-version }}
-          latestBambooVersion=${{ needs.check-for-update.outputs.bamboo-version }}
+          compatibleBambooVersion=${{ needs.check-for-update.outputs.current-compatible-version }}
+          latestBambooVersion=${{ needs.check-for-update.outputs.latest-bamboo-version }}
           
-          issueTitle="Add-on Update Request: Support for new Bamboo version"
+          issueTitle="Add-on Update Request: Support for Bamboo version $latestBambooVersion"
           issueBody=$(cat << EOF
           ## Add-on compatibility update
           - **Compatible Bamboo version:** \`$compatibleBambooVersion\`
           - **New Bamboo version:** \`$latestBambooVersion\`
           EOF
           )
-          # create issue and assign it to @team-integrations-fnm-bot
-          issueUrl=$(gh issue create --title "$issueTitle" --body "$issueBody" --assignee "@me")
-          echo $issueUrl
-          echo "::set-output name=issue-url::$issueUrl"
+
+          existingIssue=$(gh issue list -q 'map(select(.title | startswith("Add-on Update Request:") ) ) | first' --json title,number | jq '.number')
+
+          # if there's no existing issue
+          if [ -z "$existingIssue" ] 
+          then
+            # create an issue and assign it to @team-integrations-fnm-bot
+            issueUrl=$(gh issue create --title "$issueTitle" --body "$issueBody" --assignee "@me")
+          else
+            # update existing issue with new compatibility details
+            issueUrl=$(gh issue edit $existingIssue --title "$issueTitle" --body "$issueBody")
+          fi
+          echo "issue-url=$issueUrl" >> $GITHUB_OUTPUT
 
   update-pom:
     name: 'Update POM.xml'
@@ -86,7 +98,7 @@ jobs:
       - name: 'Update Bamboo version in POM.xml and commit the changes'
         id: commit-pom-update
         run: |
-          bambooVersion="${{ needs.check-for-update.outputs.bamboo-version }}"
+          bambooVersion="${{ needs.check-for-update.outputs.latest-bamboo-version }}"
           branchName="team-integrations-fnm-bot/bamboo-$bambooVersion"
           
           git config --global user.name "team-integrations-fnm-bot"
@@ -100,9 +112,9 @@ jobs:
           # if no changes were made, just silently exit
           git diff-index --quiet HEAD || (git commit -m "fix: update compatible bamboo version" \
             && git push -u origin $branchName \
-            && echo "::set-output name=changes-committed::true" \
-            && echo "::set-output name=branch-name::$branchName" \
-          )          
+            && echo "changes-committed=true" >> $GITHUB_OUTPUT \
+            && echo "branch-name=$branchName" >> $GITHUB_OUTPUT \
+          )
 
   create-pull-request:
     name: 'Create PR'
@@ -114,10 +126,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: 'Close any existing PR for Bamboo version update'
+        id: existing-pr-check
+        run: |
+          existingPr=$(gh pr list -q 'map(select(.title | startswith("Add compatibility for Bamboo version") ) ) | first' --json title,number | jq '.number')
+
+          if [ "$existingPr" ]
+          then
+            # existing pr is for a different Bamboo version, closing existing pr and a new pr will be created
+            gh pr close $existingPr --comment "Closing PR in favor of new PR for Bamboo version ${{ needs.check-for-update.outputs.bamboo-version }}" --delete-branch
+          fi
+
       - name: 'Create PR to update Bamboo version in POM.xml'
         run: |
-          title="Add compatibility for Bamboo version ${{ needs.check-for-update.outputs.bamboo-version }}"
+          title="Add compatibility for Bamboo version ${{ needs.check-for-update.outputs.latest-bamboo-version }}"
           body="Fixes ${{ needs.create-issue.outputs.gh-issue-url }}"
           head="${{ needs.update-pom.outputs.branch }}"
           
-          gh pr create --title "$title" --body "$body" --base "main" --head "$head"
+          gh pr create --title "$title" --body "$body" --base "${{ github.ref }}" --head "$head"

--- a/README.md
+++ b/README.md
@@ -66,17 +66,60 @@ java -jar atlassian-bamboo-agent-installer-<version>.jar http://bamboo-host-serv
 ## Building the Plugin
 Run the command `atlas-package` to build the plugin. The compiled plugin will be saved as `target\bamboo.jar`.
 
-## Updating the Atlassian Marketplace
+## Deploying a new version of the plugin to the Atlassian Marketplace
+
+### Automated process
+
+We use [release-please](https://github.com/googleapis/release-please) and [conventional commits](https://www.conventionalcommits.org) to generate release notes for new versions.
+
+The process once the `release-please` PR is merged is as follows:
+1. Build and package a new plugin JAR file
+2. Push the package to [Octopus](https://deploy.octopus.app/app#/Spaces-62/projects/bamboo-plugin)
+3. Automatically kick off a deployment to the `Production` environment
+   - Upload plugin JAR file using the Atlassian Marketplace REST API
+   - Create a new app version in the Atlassian Marketplace using the Atlassian Marketplace REST API
+   - Confirm that the new app version was created
+      - If the process fails to create the new app version, the deployment will fail
+
+### Manual process
 
 Keep in mind that the Bamboo plugin does not ship with the Octopus CLI tool. Updates to the CLI tool don't
 require that the Bamboo plugin be republished.
 
-To update the marketplace, use the following steps.
-
-1. Build the JAR file. You can do this locally, or get the JAR file artifact from TeamCity. 
-    - Note that if you are building locally you will need to increment the version inside the pom.xml file before building (`<version>1.0.3</version>`). This version is used by the store to show the latest artifact to end users.
-2. Browse to https://marketplace.atlassian.com/manage/plugins/com.octopus.bamboo/versions. Use the atlassian@octopus.com
+To update the marketplace, use the following steps:
+1. Build the new JAR file. 
+   - You can do this locally, or get the artifact from the GitHub Actions run for the version you want to publish. 
+   - **Note** that if you are building locally you will need to increment the version inside the pom.xml file before building (`<version>1.0.3</version>`). This version is used by the store to show the latest artifact to end users.
+2. Browse to https://marketplace.atlassian.com/manage/plugins/com.octopus.bamboo/versions. Use the `atlassian@octopus.com`
    account - credentials are in the password manager.
 3. Click the `Create version` button.
 4. Follow the wizard to upload the JAR file. The wizard will show you a lot of pages relating to how the add-on is
    to be displayed, but you can keep the exiting content. The only requirement are some release notes.
+
+### Nightly builds
+
+The nightly process is nearly identical to our release process (differences highlighted):
+1. Build and package a new **pre-release versioned** plugin JAR file
+2. Push the package to [Octopus](https://deploy.octopus.app/app#/Spaces-62/projects/bamboo-plugin)
+3. Automatically kick off a deployment to the **`Test`** environment
+   - Upload plugin JAR file using the Atlassian Marketplace REST API
+   - Create a new **private** app version in the Atlassian Marketplace using the Atlassian Marketplace REST API
+      - This version will not be visible in the marketplace for people outside the Octopus organization
+   - Confirm that the new app version was created
+      - If the process fails to create the new app version, the deployment will fail
+
+## Automated Bamboo server compatibility version updates
+
+We have a weekly scheduled [workflow](.github/workflows/bamboo-compatibility-check.yml) that checks if there has been a new version of Bamboo server released since we last updated our Bamboo plugin.
+
+This process is as follows:
+1. Check if a new version of Bamboo server has been released
+   - If there is no new version, execution is stopped
+2. Open a new issue with details of current and new Bamboo compatible versions
+   - If there is already an open issue, it will update the existing issue with the new version details
+3. Update the compatible Bamboo version in the `<bamboo.version>` and `<bamboo.data.version>` properties inside the `pom.xml` file
+4. Commit and push the changes to a new branch
+5. Open a PR for the changes
+   - The issue from step 2 above will be referenced and will be closed once the PR is merged
+
+Once the PR has been reviewed and merged, the automated `release-please` process described [above](#automated-process) will take over to push the new version of the plugin to the Atlassian Marketplace.


### PR DESCRIPTION
Now supports:
- creating/editing version update issue, and 
- closes existing version update PR if a new Bamboo version has been released

Updated README to include details about our automated processes for updating compatible Bamboo versions in the plugin

[sc-8720]