### PR TITLE
Update the Github Actions workflow to use the new secret

### DIFF
--- a/.github/workflows/bamboo-compatibility-check.yml
+++ b/.github/workflows/bamboo-compatibility-check.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  GH_TOKEN: ${{ secrets.INTEGRATIONS_FNM_BOT_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.INTEGRATIONS_FNM_BOT_TOKEN }}
+  GH_TOKEN: ${{ secrets.BAMBOO_GITHUB_ACTIONS_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.BAMBOO_GITHUB_ACTIONS_TOKEN }}
 
 jobs:
   check-for-update:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         with:
           release-type: simple
-          token: ${{ secrets.INTEGRATIONS_FNM_BOT_TOKEN }}
+          token: ${{ secrets.BAMBOO_GITHUB_ACTIONS_TOKEN }}


### PR DESCRIPTION
The `release-please` step has been [failing](https://github.com/OctopusDeploy/Octopus-Bamboo/actions/runs/8704541073) with "bad credentials". The `INTEGRATIONS_FNM_BOT_TOKEN` token in 1Password that was supposedly linked to the secret had not expired and yet it was still failing 🤷. This PR changes the release step to use a newly created token which should work.