### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           atlas-package
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: bamboo.${{ steps.git-version.outputs.nuGetVersion }}
           path: '**/target/*.jar'
@@ -96,7 +96,7 @@ jobs:
       OCTOPUS_HOST: ${{ secrets.OCTOPUS_URL }}
       OCTOPUS_SPACE: Integrations
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: bamboo.${{ needs.build.outputs.nuGetVersion }}
           path: .


### PR DESCRIPTION
upload-artifact@v3 is being [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) 